### PR TITLE
Convert EnsureSuccessStatusCode to async call

### DIFF
--- a/src/VirtoCommerce.ElasticAppSearch.Data/Extensions/HttpClientExtensions.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/Extensions/HttpClientExtensions.cs
@@ -81,6 +81,10 @@ public static class HttpClientExtensions
             var result = JsonConvert.DeserializeObject<TResult>(content, jsonSerializerSettings);
             throw new SearchException(result?.ToString(), exception);
         }
+        finally
+        {
+            throw new SearchException($"ElasticAppSearch: ({httpResponseMessage.StatusCode}) {httpResponseMessage.ReasonPhrase}");
+        }
     }
 
     public static StringContent ToJson<TValue>(this TValue value, JsonSerializerSettings jsonSerializerSettings = null)

--- a/src/VirtoCommerce.ElasticAppSearch.Data/Services/ElasticAppSearchApiClient.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/Services/ElasticAppSearchApiClient.cs
@@ -84,7 +84,7 @@ public class ElasticAppSearchApiClient : IElasticAppSearchApiClient
     {
         var response = await _httpClient.PostAsJsonAsync(GetDocumentsEndpoint(engineName), documents, ModuleConstants.Api.JsonSerializerSettings);
 
-        response.EnsureSuccessStatusCode();
+        await response.EnsureSuccessStatusCodeAsync<CreateOrUpdateDocumentResult[]>(ModuleConstants.Api.JsonSerializerSettings);
 
         return await response.Content.ReadFromJsonAsync<CreateOrUpdateDocumentResult[]>(ModuleConstants.Api.JsonSerializerSettings);
     }
@@ -93,7 +93,7 @@ public class ElasticAppSearchApiClient : IElasticAppSearchApiClient
     {
         var response = await _httpClient.DeleteAsJsonAsync(GetDocumentsEndpoint(engineName), ids, ModuleConstants.Api.JsonSerializerSettings);
 
-        response.EnsureSuccessStatusCode();
+        await response.EnsureSuccessStatusCodeAsync<DeleteDocumentResult[]>(ModuleConstants.Api.JsonSerializerSettings);
 
         return await response.Content.ReadFromJsonAsync<DeleteDocumentResult[]>(ModuleConstants.Api.JsonSerializerSettings);
     }


### PR DESCRIPTION
## Description
Sync EnsureSuccessStatusCode doesn't provide exception details so i convert all sync calls to async. Deserialization of response can produce exception which makes no sense for consumer, hence i think we need to show original message to consumer.
## References
### QA-test:
### Jira-link:
### Artifact URL:
