### PR TITLE
Use a special sorting field name (_score) to order by relevance

### DIFF
--- a/src/VirtoCommerce.ElasticAppSearch.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/ModuleConstants.cs
@@ -54,6 +54,8 @@ public static class ModuleConstants
 
             public const string ObjectFieldName = "__object";
 
+            public const string ScoreFieldName = "_score";
+
             public static readonly string[] Reserved = { "external_id", "engine_id", "highlight", "or", "and", "not", "any", "all", "none" };
 
             public const string ReservedFieldNamesPrefix = "field_";

--- a/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchQueryBuilder.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchQueryBuilder.cs
@@ -148,7 +148,7 @@ public class SearchQueryBuilder : ISearchQueryBuilder
     protected virtual ISort[] GetSorting(IEnumerable<SortingField> sortingFields, Schema schema)
     {
         var result = sortingFields?.Select(GetSortingField)
-            .Where(x => schema.Fields.ContainsKey(x.FieldName))
+            .Where(x => schema.Fields.ContainsKey(x.FieldName) || x.FieldName == ModuleConstants.Api.FieldNames.ScoreFieldName)
             .ToArray();
 
         return result;


### PR DESCRIPTION
## Description
- Use a special sorting field name (_score) to order by relevance
## References
https://www.elastic.co/guide/en/app-search/current/sort.html
### QA-test:
### Jira-link:
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticAppSearch_3.212.0-pr-30-c973.zip
