### PR TITLE
PT-14218: Support different search provider for each document type

### DIFF
--- a/src/VirtoCommerce.ElasticAppSearch.Core/Models/Api/Search/Query/Boosts/Boost.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/Models/Api/Search/Query/Boosts/Boost.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace VirtoCommerce.ElasticAppSearch.Core.Models.Api.Search.Query.Boosts;
+
+public class Boost
+{
+    [JsonRequired]
+    public virtual string Type { get; set; }
+
+    /// <summary>
+    /// Must be between 0 and 10. Defaults to 1.0. A negative factor or fractional factor will not deboost a result.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public double? Factor { get; set; }
+}

--- a/src/VirtoCommerce.ElasticAppSearch.Core/Models/Api/Search/Query/Boosts/ValueBoost.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/Models/Api/Search/Query/Boosts/ValueBoost.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+using static VirtoCommerce.ElasticAppSearch.Core.ModuleConstants.Api;
+
+namespace VirtoCommerce.ElasticAppSearch.Core.Models.Api.Search.Query.Boosts;
+
+/// <summary>
+/// Available on text, number, and date fields.
+/// </summary>
+public class ValueBoost : Boost
+{
+    public override string Type => BoostTypes.Value;
+
+    [JsonRequired]
+    public string Value { get; set; }
+
+    /// <summary>
+    /// Can be "add" or "multiply". Defaults to "add".
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string Operation { get; set; }
+}

--- a/src/VirtoCommerce.ElasticAppSearch.Core/Models/Api/Search/Query/SearchQuery.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/Models/Api/Search/Query/SearchQuery.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Json;
+using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Search.Query.Boosts;
 using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Search.Query.Facets;
 using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Search.Query.Filters;
 using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Search.Query.Sorting;
@@ -34,4 +35,8 @@ public record SearchQuery
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     [CustomJsonProperty(EmptyValueHandling = EmptyValueHandling.Ignore)]
     public Dictionary<string, Facet> Facets { get; set; } = new();
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    [CustomJsonProperty(EmptyValueHandling = EmptyValueHandling.Ignore)]
+    public Dictionary<string, Boost[]> Boosts { get; set; } = new();
 }

--- a/src/VirtoCommerce.ElasticAppSearch.Core/Models/BoostPreset.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/Models/BoostPreset.cs
@@ -1,0 +1,30 @@
+namespace VirtoCommerce.ElasticAppSearch.Core.Models
+{
+    public class BoostPreset
+    {
+        /// <summary>
+        /// Preset name: high, medium, normal, low
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Elastic App Search API boost type: value, functional, proximity or recency
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// type of boost operation if boost type is Value or Functional: multiply or add.
+        /// </summary>
+        public string Operation { get; set; }
+
+        /// <summary>
+        /// Boost factor. Must be between 0 and 10. Defaults to 1.0;
+        /// </summary>
+        public double Factor { get; set; } = 1.0;
+
+        /// <summary>
+        /// Indicates default preset. Default will be applied if no suitable boost preset found.
+        /// </summary>
+        public bool IsDefault { get; set; }
+    }
+}

--- a/src/VirtoCommerce.ElasticAppSearch.Core/Models/ElasticAppSearchOptions.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/Models/ElasticAppSearchOptions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace VirtoCommerce.ElasticAppSearch.Core.Models;
 
 public class ElasticAppSearchOptions
@@ -19,4 +21,6 @@ public class ElasticAppSearchOptions
     /// Gets or sets the path to the App Search engine in the Kibana Dashboard. Default value: /app/enterprise_search/app_search/engines/.
     /// </summary>
     public string KibanaPath { get; set; } = "/app/enterprise_search/app_search/engines/";
+
+    public List<BoostPreset> BoostPresets { get; set; } = new();
 }

--- a/src/VirtoCommerce.ElasticAppSearch.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/ModuleConstants.cs
@@ -76,6 +76,28 @@ public static class ModuleConstants
         {
             public const int MaxDepth = 5;
         }
+
+        public static class BoostTypes
+        {
+            public const string Value = "value";
+            public const string Functional = "functional";
+            public const string Proximity = "proximity";
+            public const string Recency = "proximity";
+        }
+
+        public static class BoostOperations
+        {
+            public const string Multiply = "multiply";
+            public const string Add = "add";
+        }
+
+        public static class BoostFunctions
+        {
+            public const string Linear = "linear";
+            public const string Exponential = "exponential";
+            public const string Logarithmic = "logarithmic";
+            public const string Gaussian = "gaussian";
+        }
     }
 
     public static class Security

--- a/src/VirtoCommerce.ElasticAppSearch.Core/Services/Builders/ISearchBoostsBuilder.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/Services/Builders/ISearchBoostsBuilder.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Schema;
+using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Search.Query.Boosts;
+using VirtoCommerce.SearchModule.Core.Model;
+
+namespace VirtoCommerce.ElasticAppSearch.Core.Services.Builders
+{
+    public interface ISearchBoostsBuilder
+    {
+        Dictionary<string, Boost[]> ToBoosts(IList<SearchBoost> boosts, Schema schema);
+    }
+}

--- a/src/VirtoCommerce.ElasticAppSearch.Core/VirtoCommerce.ElasticAppSearch.Core.csproj
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/VirtoCommerce.ElasticAppSearch.Core.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.222.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.721-pt-14218" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.ElasticAppSearch.Core/VirtoCommerce.ElasticAppSearch.Core.csproj
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/VirtoCommerce.ElasticAppSearch.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.723-pt-14218" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.ElasticAppSearch.Core/VirtoCommerce.ElasticAppSearch.Core.csproj
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/VirtoCommerce.ElasticAppSearch.Core.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.721-pt-14218" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.723-pt-14218" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchBoostsBuilder.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchBoostsBuilder.cs
@@ -30,7 +30,7 @@ namespace VirtoCommerce.ElasticAppSearch.Data.Services.Builders
         {
             if (boosts.IsNullOrEmpty() || _boostPresets.IsNullOrEmpty())
             {
-                return null;
+                return new Dictionary<string, Boost[]>();
             }
 
             var result = boosts

--- a/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchBoostsBuilder.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchBoostsBuilder.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Options;
+using VirtoCommerce.ElasticAppSearch.Core.Models;
+using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Schema;
+using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Search.Query.Boosts;
+using VirtoCommerce.ElasticAppSearch.Core.Services.Builders;
+using VirtoCommerce.ElasticAppSearch.Core.Services.Converters;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.SearchModule.Core.Model;
+using static VirtoCommerce.ElasticAppSearch.Core.ModuleConstants.Api;
+
+namespace VirtoCommerce.ElasticAppSearch.Data.Services.Builders
+{
+    public class SearchBoostsBuilder : ISearchBoostsBuilder
+    {
+        private readonly List<BoostPreset> _boostPresets;
+        private readonly IFieldNameConverter _fieldNameConverter;
+
+        public SearchBoostsBuilder(
+            IOptions<ElasticAppSearchOptions> options,
+            IFieldNameConverter fieldNameConverter)
+        {
+            _boostPresets = options.Value?.BoostPresets ?? new List<BoostPreset>();
+
+            _fieldNameConverter = fieldNameConverter;
+        }
+
+        public Dictionary<string, Boost[]> ToBoosts(IList<SearchBoost> boosts, Schema schema)
+        {
+            if (boosts.IsNullOrEmpty() || _boostPresets.IsNullOrEmpty())
+            {
+                return null;
+            }
+
+            var result = boosts
+                .GroupBy(x => _fieldNameConverter.ToProviderFieldName(x.FieldName))
+                .Where(x => schema.Fields.ContainsKey(x.Key))
+                .ToDictionary(x => x.Key, x =>
+                {
+                    var apiBoosts = new List<Boost>();
+
+                    foreach (var searchBoost in x)
+                    {
+                        var apiBoost = ToApiBoost(searchBoost);
+                        if (apiBoost != null)
+                        {
+                            apiBoosts.Add(apiBoost);
+                        }
+                    }
+
+                    return apiBoosts.Any() ? apiBoosts.ToArray() : null;
+                });
+
+            return result;
+        }
+
+        private Boost ToApiBoost(SearchBoost searchBoost)
+        {
+            var preset = _boostPresets.FirstOrDefault(x => x.Name.EqualsInvariant(searchBoost.Preset))
+                ?? _boostPresets.FirstOrDefault(x => x.IsDefault);
+
+            if (preset == null)
+            {
+                return null;
+            }
+
+            var boost = default(Boost);
+
+            switch (preset.Type)
+            {
+                case BoostTypes.Value:
+                    boost = new ValueBoost
+                    {
+                        Value = searchBoost.Value,
+                        Operation = preset.Operation,
+                        Factor = preset.Factor,
+                    };
+
+                    break;
+            }
+
+            return boost;
+        }
+    }
+}

--- a/src/VirtoCommerce.ElasticAppSearch.Data/VirtoCommerce.ElasticAppSearch.Data.csproj
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/VirtoCommerce.ElasticAppSearch.Data.csproj
@@ -20,7 +20,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.210.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.400.0" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.ElasticAppSearch.Web/Module.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Web/Module.cs
@@ -35,6 +35,7 @@ public class Module : IModule, IHasConfiguration
         serviceCollection.AddSingleton<IFieldNameConverter, FieldNameConverter>();
         serviceCollection.AddSingleton<IDocumentConverter, DocumentConverter>();
         serviceCollection.AddSingleton<ISearchFiltersBuilder, SearchFiltersBuilder>();
+        serviceCollection.AddSingleton<ISearchBoostsBuilder, SearchBoostsBuilder>();
         serviceCollection.AddSingleton<ISearchQueryBuilder, SearchQueryBuilder>();
         serviceCollection.AddSingleton<ISearchResponseBuilder, SearchResponseBuilder>();
         serviceCollection.AddSingleton<ElasticAppSearchProvider>();

--- a/src/VirtoCommerce.ElasticAppSearch.Web/module.manifest
+++ b/src/VirtoCommerce.ElasticAppSearch.Web/module.manifest
@@ -3,12 +3,12 @@
   <id>VirtoCommerce.ElasticAppSearch</id>
   <version>3.213.0</version>
   <version-tag />
-  
+
   <platformVersion>3.400.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Search" version="3.403.0" />
   </dependencies>
-  
+
   <apps>
     <app id="app_search">
       <title>App Search</title>

--- a/src/VirtoCommerce.ElasticAppSearch.Web/module.manifest
+++ b/src/VirtoCommerce.ElasticAppSearch.Web/module.manifest
@@ -3,10 +3,12 @@
   <id>VirtoCommerce.ElasticAppSearch</id>
   <version>3.213.0</version>
   <version-tag />
-  <platformVersion>3.210.0</platformVersion>
+  
+  <platformVersion>3.400.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Search" version="3.222.0" />
+    <dependency id="VirtoCommerce.Search" version="3.403.0" />
   </dependencies>
+  
   <apps>
     <app id="app_search">
       <title>App Search</title>

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/Api/Json/Search/Query/Boosts/Value.json
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/Api/Json/Search/Query/Boosts/Value.json
@@ -1,0 +1,19 @@
+{
+  "query": "park",
+  "boosts": {
+    "state": [
+      {
+        "type": "value",
+        "value": "TX",
+        "operation": "multiply",
+        "factor": 10.0
+      },
+      {
+        "type": "value",
+        "value": "MN",
+        "operation": "add",
+        "factor": 5.0
+      }
+    ]
+  }
+}

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/Api/Search/Query/Boosts/ValueBoostsSerializationTests.cs
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/Api/Search/Query/Boosts/ValueBoostsSerializationTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.IO;
+using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Search.Query;
+using VirtoCommerce.ElasticAppSearch.Core.Models.Api.Search.Query.Boosts;
+using Xunit;
+
+namespace VirtoCommerce.ElasticAppSearch.Tests.Api.Search.Query.Boosts
+{
+    public class ValueBoostsSerializationTests : SerializationTestsBase
+    {
+        public static IEnumerable<object[]> SerializationData => new[]
+        {
+            new object[]
+            {
+                //query
+                new SearchQuery
+                {
+                    Query = "park",
+                    Boosts = new Dictionary<string, Boost[]>
+                    {
+                        { "state", new Boost[]
+                                    {
+                                        new ValueBoost
+                                        {
+                                            Value = "TX",
+                                            Operation = "multiply",
+                                            Factor = 10.0,
+                                        },
+                                        new ValueBoost
+                                        {
+                                            Value = "MN",
+                                            Operation = "add",
+                                            Factor = 5.0,
+                                        }
+                                    }
+                        },
+                    },
+                },
+                //json
+                "Value.json"
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(SerializationData))]
+        public override void Serialize_Entity_CorrectlySerializes<T>(T actual, string expectedJsonFileName)
+        {
+            base.Serialize_Entity_CorrectlySerializes(actual, expectedJsonFileName);
+        }
+
+        protected override string GetJsonPath()
+        {
+            return Path.Combine(base.GetJsonPath(), "Search", "Query", "Boosts");
+        }
+    }
+}

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/ElasticAppSearchTests.cs
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/ElasticAppSearchTests.cs
@@ -102,7 +102,6 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
 
         protected override ISearchProvider GetSearchProvider()
         {
-
             var host = Environment.GetEnvironmentVariable("TestElasticAppSearchHost") ?? "http://localhost:3002";
             var privateApiKey = Environment.GetEnvironmentVariable("TestElasticAppSearchPrivateKey") ?? "";
 
@@ -113,7 +112,6 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
 
             services.AddHttpClient(ModuleConstants.ModuleName, (_, httpClient) =>
             {
-
                 httpClient.BaseAddress = new Uri($"{host}/api/as/v1/");
 
                 httpClient.DefaultRequestHeaders.Add(HeaderNames.Authorization, $"Bearer {privateApiKey}");
@@ -130,12 +128,14 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
 
             var httpFactory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
 
-            var apiClient = new ElasticAppSearchApiClient(httpFactory, Mock.Of<ILogger<ElasticAppSearchApiClient>>(), Mock.Of<IOptions<ElasticAppSearchOptions>>());
+            var appSearchOptionsMock = Mock.Of<IOptions<ElasticAppSearchOptions>>();
+            var apiClient = new ElasticAppSearchApiClient(httpFactory, Mock.Of<ILogger<ElasticAppSearchApiClient>>(), appSearchOptionsMock);
             var fieldNameConverter = new FieldNameConverter();
             var documentConverter = new DocumentConverter(Mock.Of<ILogger<DocumentConverter>>(), fieldNameConverter);
             var searchFilterBuilder = new SearchFiltersBuilder(Mock.Of<ILogger<SearchFiltersBuilder>>(), fieldNameConverter);
             var facetsBuilder = new SearchFacetsQueryBuilder(Mock.Of<ILogger<SearchFacetsQueryBuilder>>(), fieldNameConverter, searchFilterBuilder);
-            var searchQueryBuilder = new SearchQueryBuilder(Mock.Of<ILogger<SearchQueryBuilder>>(), fieldNameConverter, searchFilterBuilder, facetsBuilder);
+            var boostsBuilder = new SearchBoostsBuilder(appSearchOptionsMock, fieldNameConverter);
+            var searchQueryBuilder = new SearchQueryBuilder(Mock.Of<ILogger<SearchQueryBuilder>>(), fieldNameConverter, searchFilterBuilder, facetsBuilder, boostsBuilder);
             var aggregationsResponseBuilder = new AggregationsResponseBuilder(fieldNameConverter);
             var searchResponseBuilder = new SearchResponseBuilder(documentConverter, aggregationsResponseBuilder);
             var memoryCache = new MemoryCache(new MemoryCacheOptions());

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchProviderTests.cs
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchProviderTests.cs
@@ -235,7 +235,7 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
             var request = new SearchRequest
             {
                 SearchKeywords = " shirt ",
-                SearchFields = new[] { "Content" },
+                SearchFields = new[] { "__content" },
                 Take = 10,
             };
 
@@ -247,7 +247,7 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
             request = new SearchRequest
             {
                 SearchKeywords = "\"red shirt\"",
-                SearchFields = new[] { "Content" },
+                SearchFields = new[] { "__content" },
                 Take = 10,
             };
 

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchProviderTestsBase.cs
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchProviderTestsBase.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Moq;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.SearchModule.Core.Extensions;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
 
@@ -42,50 +43,47 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
         {
             var doc = new IndexDocument(id);
 
-            doc.Add(new IndexDocumentField("Content", name) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("Content", color) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
+            doc.AddFilterableStringAndContentString("Name", name);
+            doc.AddFilterableStringAndContentString("Color", color);
 
-            doc.Add(new IndexDocumentField("Code", id) { IsRetrievable = true, IsFilterable = true });
-            doc.Add(new IndexDocumentField("Name", name) { IsRetrievable = true, IsFilterable = true });
-            doc.Add(new IndexDocumentField("Color", color) { IsRetrievable = true, IsFilterable = true });
-            doc.Add(new IndexDocumentField("Size", size) { IsRetrievable = true, IsFilterable = true });
-            doc.Add(new IndexDocumentField("Date", DateTime.Parse(date)) { IsRetrievable = true, IsFilterable = true });
-            doc.Add(new IndexDocumentField("Location", GeoPoint.TryParse(location)) { IsRetrievable = true, IsFilterable = true });
+            doc.AddFilterableString("Code", id);
+            doc.AddFilterableInteger("Size", size);
+            doc.AddFilterableDateTime("Date", DateTime.Parse(date));
+            doc.Add(new IndexDocumentField("Location", GeoPoint.TryParse(location), IndexDocumentFieldValueType.GeoPoint) { IsRetrievable = true, IsFilterable = true });
 
-            doc.Add(new IndexDocumentField("Catalog", "Goods") { IsRetrievable = true, IsFilterable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("Catalog", "Stuff") { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+            doc.AddFilterableCollection("Catalog", "Goods");
+            doc.AddFilterableCollection("Catalog", "Stuff");
 
-            doc.Add(new IndexDocumentField("NumericCollection", size) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("NumericCollection", 10) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("NumericCollection", 20) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+            doc.Add(new IndexDocumentField("NumericCollection", size, IndexDocumentFieldValueType.Integer) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+            doc.Add(new IndexDocumentField("NumericCollection", 10, IndexDocumentFieldValueType.Integer) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+            doc.Add(new IndexDocumentField("NumericCollection", 20, IndexDocumentFieldValueType.Integer) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
 
-            doc.Add(new IndexDocumentField("Is", "Priced") { IsFilterable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("Is", color) { IsFilterable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("Is", id) { IsFilterable = true, IsCollection = true });
+            doc.AddFilterableCollection("Is", "Priced");
+            doc.AddFilterableCollection("Is", color);
+            doc.AddFilterableCollection("Is", id);
 
-            doc.Add(new IndexDocumentField("StoredField", "This value should not be processed in any way, it is just stored in the index.") { IsRetrievable = true });
+            doc.Add(new IndexDocumentField("StoredField", "This value should not be processed in any way, it is just stored in the index.", IndexDocumentFieldValueType.String) { IsRetrievable = true });
 
             foreach (var price in prices)
             {
-                doc.Add(new IndexDocumentField($"Price_{price.Currency}_{price.Pricelist}", price.Amount) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
-                doc.Add(new IndexDocumentField($"Price_{price.Currency}", price.Amount) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+                doc.Add(new IndexDocumentField($"Price_{price.Currency}_{price.Pricelist}", price.Amount, IndexDocumentFieldValueType.Decimal) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+                doc.Add(new IndexDocumentField($"Price_{price.Currency}", price.Amount, IndexDocumentFieldValueType.Decimal) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
             }
 
-            var hasMultiplePrices = prices.Length > 1;
-            doc.Add(new IndexDocumentField("HasMultiplePrices", hasMultiplePrices) { IsRetrievable = true, IsFilterable = true });
+            doc.AddFilterableBoolean("HasMultiplePrices", prices.Length > 1);
 
             // Adds extra fields to test mapping updates for indexer
             if (name2 != null)
             {
-                doc.Add(new IndexDocumentField("Name 2", name2) { IsRetrievable = true, IsFilterable = true });
+                doc.AddFilterableString("Name 2", name2);
             }
 
             if (date2 != null)
             {
-                doc.Add(new IndexDocumentField("Date (2)", date2) { IsRetrievable = true, IsFilterable = true });
+                doc.AddFilterableDateTime("Date (2)", date2.Value);
             }
 
-            doc.Add(new IndexDocumentField("__obj", obj) { IsRetrievable = true, IsFilterable = true });
+            doc.Add(new IndexDocumentField("__obj", obj, IndexDocumentFieldValueType.Complex) { IsRetrievable = true, IsFilterable = true });
 
             return doc;
         }

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchProviderTestsBase.cs
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchProviderTestsBase.cs
@@ -43,12 +43,10 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
         {
             var doc = new IndexDocument(id);
 
-            doc.Add(new IndexDocumentField("Content", name, IndexDocumentFieldValueType.String) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
-            doc.Add(new IndexDocumentField("Content", color, IndexDocumentFieldValueType.String) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
+            doc.AddFilterableStringAndContentString("Name", name);
+            doc.AddFilterableStringAndContentString("Color", color);
 
             doc.AddFilterableString("Code", id);
-            doc.AddFilterableString("Name", name);
-            doc.AddFilterableString("Color", color);
             doc.AddFilterableInteger("Size", size);
             doc.AddFilterableDateTime("Date", DateTime.Parse(date));
             doc.Add(new IndexDocumentField("Location", GeoPoint.TryParse(location), IndexDocumentFieldValueType.GeoPoint) { IsRetrievable = true, IsFilterable = true });

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchProviderTestsBase.cs
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchProviderTestsBase.cs
@@ -43,8 +43,8 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
         {
             var doc = new IndexDocument(id);
 
-            doc.AddFilterableStringAndContentString("Name", name);
-            doc.AddFilterableStringAndContentString("Color", color);
+            doc.Add(new IndexDocumentField("Content", name, IndexDocumentFieldValueType.String) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
+            doc.Add(new IndexDocumentField("Content", color, IndexDocumentFieldValueType.String) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
 
             doc.AddFilterableString("Code", id);
             doc.AddFilterableInteger("Size", size);

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchProviderTestsBase.cs
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchProviderTestsBase.cs
@@ -47,6 +47,8 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
             doc.Add(new IndexDocumentField("Content", color, IndexDocumentFieldValueType.String) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
 
             doc.AddFilterableString("Code", id);
+            doc.AddFilterableString("Name", name);
+            doc.AddFilterableString("Color", color);
             doc.AddFilterableInteger("Size", size);
             doc.AddFilterableDateTime("Date", DateTime.Parse(date));
             doc.Add(new IndexDocumentField("Location", GeoPoint.TryParse(location), IndexDocumentFieldValueType.GeoPoint) { IsRetrievable = true, IsFilterable = true });

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchQueryBuilderTests.cs
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchQueryBuilderTests.cs
@@ -126,7 +126,8 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
             var fieldNameConverter = GetFieldNameConverter();
             var searchFiltersBuilder = GetSearchFiltersBuilder();
             var searchFacetsQueryBuilder = GetSearchFacetsQueryBuilder();
-            var searchQueryBuilder = new SearchQueryBuilder(logger, fieldNameConverter, searchFiltersBuilder, searchFacetsQueryBuilder);
+            var searchBoostsBuilder = GetSearchBoostsBulder();
+            var searchQueryBuilder = new SearchQueryBuilder(logger, fieldNameConverter, searchFiltersBuilder, searchFacetsQueryBuilder, searchBoostsBuilder);
             var request = searchRequest();
             var schema = GetSchema();
 
@@ -176,6 +177,12 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
         private static ISearchFacetsQueryBuilder GetSearchFacetsQueryBuilder()
         {
             var mock = new Mock<ISearchFacetsQueryBuilder>();
+            return mock.Object;
+        }
+
+        private static ISearchBoostsBuilder GetSearchBoostsBulder()
+        {
+            var mock = new Mock<ISearchBoostsBuilder>();
             return mock.Object;
         }
     }


### PR DESCRIPTION
## Description
Configuration example for default provider `ElasticAppSearch` and category provider `ElasticSearch8`:
```
{
  "Search": {
    "Provider": "ElasticAppSearch",
    "DocumentScopes": [
      {
        "DocumentType": "Category",
        "Provider": "ElasticSearch8"
      }
    ]
  }
}
```
## References
### QA-test:
### Jira-link:






https://virtocommerce.atlassian.net/browse/PT-14218
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticAppSearch_3.213.0-pr-31-6a2c.zip
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticAppSearch_3.213.0-pr-31-88f2.zip
