### PR TITLE
VCST-1633: Search products by keyword do not return any results

### DIFF
--- a/src/VirtoCommerce.ElasticAppSearch.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/ModuleConstants.cs
@@ -114,27 +114,6 @@ public static class ModuleConstants
 
     public static class Settings
     {
-        public const int DefaultTotalFieldsLimit = 1000;
-
-        public static class Indexing
-        {
-            public static SettingDescriptor IndexTotalFieldsLimit { get; } = new()
-            {
-                Name = "VirtoCommerce.Search.ElasticAppSearch.IndexTotalFieldsLimit",
-                GroupName = "Search|ElasticSearch",
-                ValueType = SettingValueType.Integer,
-                DefaultValue = DefaultTotalFieldsLimit,
-            };
-
-            public static IEnumerable<SettingDescriptor> AllIndexingSettings
-            {
-                get
-                {
-                    yield return IndexTotalFieldsLimit;
-                }
-            }
-        }
-
-        public static IEnumerable<SettingDescriptor> AllSettings => Indexing.AllIndexingSettings;
+        public static IEnumerable<SettingDescriptor> AllSettings => [];
     }
 }

--- a/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchQueryBuilder.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchQueryBuilder.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -191,7 +190,7 @@ public class SearchQueryBuilder : ISearchQueryBuilder
 
     protected virtual Dictionary<string, SearchFieldValue> GetSearchFields(IEnumerable<string> searchFields)
     {
-        searchFields = searchFields?.Where(x => !ModuleConstants.Api.FieldNames.IgnoredForSearch.Contains(x));
+        searchFields = searchFields?.Where(x => !ModuleConstants.Api.FieldNames.IgnoredForSearch.Any(ignoredField => x.StartsWith(ignoredField)));
 
         var result = searchFields?.ToDictionary(searchField => _fieldNameConverter.ToProviderFieldName(searchField), _ => new SearchFieldValue());
 


### PR DESCRIPTION
## Description
fix: Search products by keyword do not return any results if SearchFields contains _content_en_us or any custom localization.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1633
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticAppSearch_3.804.0-pr-37-8de6.zip