### PR TITLE
VCST-2966: Update suggestion endpoint in ElasticAppSearchApiClient

### DIFF
--- a/src/VirtoCommerce.ElasticAppSearch.Data/Services/ElasticAppSearchApiClient.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/Services/ElasticAppSearchApiClient.cs
@@ -322,7 +322,7 @@ public class ElasticAppSearchApiClient : IElasticAppSearchApiClient
 
     private static string GetSuggestionEndpoint(string engineName)
     {
-        return $"{GetEngineEndpoint(engineName)}/search_explain";
+        return $"{GetEngineEndpoint(engineName)}/query_suggestion";
     }
 
     private static string GetSearchExplainEndpoint(string engineName)


### PR DESCRIPTION
## Description
fix: Changed the return value of the `GetSuggestionEndpoint` method from `"/search_explain"` to `"/query_suggestion"` to reflect the new endpoint for fetching query suggestions.


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2966
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticAppSearch_3.808.0-pr-41-f234.zip