### PR TITLE
VCST-3529: Remove limitations to max facet value to 250.

### DIFF
--- a/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchFacetsQueryBuilder.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchFacetsQueryBuilder.cs
@@ -15,6 +15,10 @@ namespace VirtoCommerce.ElasticAppSearch.Data.Services.Builders;
 
 public class SearchFacetsQueryBuilder : ISearchFacetsQueryBuilder
 {
+    /// <summary>
+    /// By default, Elastic App Search returns 10 facet values for each facet. The maximum number of facet values is 250.
+    /// You can change the number of facet values returned by app_search.engine.total_facet_values_returned.limit.
+    /// </summary>
     protected const int MaxFacetValues = 250;
 
     private readonly ILogger<SearchFacetsQueryBuilder> _logger;
@@ -101,7 +105,7 @@ public class SearchFacetsQueryBuilder : ISearchFacetsQueryBuilder
                 result = new ValueFacet
                 {
                     Name = fieldName,
-                    Size = termAggregationRequest.Size == 0 || termAggregationRequest.Size > MaxFacetValues
+                    Size = termAggregationRequest.Size == 0
                         ? MaxFacetValues
                         : termAggregationRequest.Size,
                 };


### PR DESCRIPTION
## Description
fix: Added documentation for default facet value behavior in Elastic App Search, specifying the default of 10 and a maximum of 250. Updated logic for the Size property in ValueFacet to default to MaxFacetValues when termAggregationRequest.Size is 0, ensuring clarity and adherence to the maximum limit. You can change the number of facet values returned by app_search.engine.total_facet_values_returned.limit and then pass it using size value in TermAggregationRequest.

## References
### QA-test:
### Jira-link:
### Artifact URL:
