### PR TITLE
feat: Update to NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.817.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.ElasticAppSearch.Core/VirtoCommerce.ElasticAppSearch.Core.csproj
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/VirtoCommerce.ElasticAppSearch.Core.csproj
@@ -7,8 +7,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ElasticAppSearch.Core/VirtoCommerce.ElasticAppSearch.Core.csproj
+++ b/src/VirtoCommerce.ElasticAppSearch.Core/VirtoCommerce.ElasticAppSearch.Core.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.821.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
+    
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ElasticAppSearch.Data/VirtoCommerce.ElasticAppSearch.Data.csproj
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/VirtoCommerce.ElasticAppSearch.Data.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
@@ -10,8 +10,7 @@
     <ProjectReference Include="..\VirtoCommerce.ElasticAppSearch.Core\VirtoCommerce.ElasticAppSearch.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.917.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ElasticAppSearch.Web/VirtoCommerce.ElasticAppSearch.Web.csproj
+++ b/src/VirtoCommerce.ElasticAppSearch.Web/VirtoCommerce.ElasticAppSearch.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/VirtoCommerce.ElasticAppSearch.Web/module.manifest
+++ b/src/VirtoCommerce.ElasticAppSearch.Web/module.manifest
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.ElasticAppSearch</id>
-  <version>3.817.0</version>
+  <version>3.1000.0</version>
   <version-tag />
   
-  <platformVersion>3.917.0</platformVersion>  
+  <platformVersion>3.1002.0</platformVersion>  
   <dependencies>
-    <dependency id="VirtoCommerce.Search" version="3.821.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
   </dependencies>
   
   <apps>

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/VirtoCommerce.ElasticAppSearch.Tests.csproj
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/VirtoCommerce.ElasticAppSearch.Tests.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/VirtoCommerce.ElasticAppSearch.Tests.csproj
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/VirtoCommerce.ElasticAppSearch.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -8,11 +8,11 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description
feat: Update to NET10

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticAppSearch_3.1000.0-pr-50-ac17.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades all projects to `net10.0` and bumps core platform/search dependencies, which can introduce runtime or compatibility issues despite minimal code changes.
> 
> **Overview**
> Updates the module to target **.NET 10** across `Core`, `Data`, `Web`, and test projects, and bumps the module/package version to `3.1000.0`.
> 
> Aligns dependencies to the `3.1000.x` VirtoCommerce platform/search stack and .NET 10-era `Microsoft.Extensions.*` packages (plus `FluentAssertions`), and updates `module.manifest` platform/dependency version requirements accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac17f13ad90bdbce31d86d41ce1f4d4fd178dd5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->