### PR TITLE
VCST-5370: Relevance field support

### DIFF
--- a/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchQueryBuilder.cs
+++ b/src/VirtoCommerce.ElasticAppSearch.Data/Services/Builders/SearchQueryBuilder.cs
@@ -181,6 +181,16 @@ public class SearchQueryBuilder : ISearchQueryBuilder
                 }
             };
         }
+        else if (IsScoreField(field))
+        {
+            // Relevance sort. Other providers (and the storefront) emit the "score" token; App Search exposes
+            // relevance only as the built-in "_score" field, so bind both spellings to it.
+            result = new FieldSort
+            {
+                FieldName = ModuleConstants.Api.FieldNames.ScoreFieldName,
+                Value = field.IsDescending ? SortOrder.Desc : SortOrder.Asc
+            };
+        }
         else
         {
             result = new FieldSort
@@ -191,6 +201,14 @@ public class SearchQueryBuilder : ISearchQueryBuilder
         }
 
         return result;
+    }
+
+    // True for the relevance ("score") sort. Accepts the cross-provider "score" token (what the storefront sends)
+    // and App Search's own "_score", so a relevance clause is never silently dropped from sorting.
+    protected virtual bool IsScoreField(SortingField field)
+    {
+        return field.FieldName.EqualsIgnoreCase("score") ||
+               field.FieldName.EqualsIgnoreCase(ModuleConstants.Api.FieldNames.ScoreFieldName);
     }
 
     protected virtual Dictionary<string, SearchFieldValue> GetSearchFields(IEnumerable<string> searchFields)

--- a/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchQueryBuilderTests.cs
+++ b/tests/VirtoCommerce.ElasticAppSearch.Tests/SearchQueryBuilderTests.cs
@@ -107,6 +107,35 @@ namespace VirtoCommerce.ElasticAppSearch.Tests
         }
 
         [Theory]
+        [InlineData("score")]
+        [InlineData("_score")]
+        [InlineData("SCORE")]
+        public void ToSearchQuery_ScoreToken_MapsToRelevanceField(string scoreToken)
+        {
+            // The storefront and the other providers emit "score"; App Search exposes relevance only as the
+            // built-in "_score" field (not part of the schema), so the token must bind to "_score" and survive.
+            Test(
+                () => new SearchRequest { Sorting = new SortingField[] { new(scoreToken, true) } },
+                searchQuery => searchQuery.Sort,
+                new FieldSort[] { new() { FieldName = "_score", Value = SortOrder.Desc } });
+        }
+
+        [Fact]
+        public void ToSearchQuery_ScoreWithSchemaTieBreaker_KeepsRelevanceAndKnownField()
+        {
+            // Featured-style expression: relevance first, then a tie-breaker. Relevance survives as "_score";
+            // schema fields survive as themselves (unknown fields are still dropped by GetSorting).
+            Test(
+                () => new SearchRequest { Sorting = new SortingField[] { new("score", true), new("test1") } },
+                searchQuery => searchQuery.Sort,
+                new FieldSort[]
+                {
+                    new() { FieldName = "_score", Value = SortOrder.Desc },
+                    new() { FieldName = "test1", Value = SortOrder.Asc },
+                });
+        }
+
+        [Theory]
         [MemberData(nameof(SearchFieldsData))]
         public void ToSearchQuery_ConvertValidSearchFields_Successfully(string[] searchFields, object expectedResult)
         {


### PR DESCRIPTION
## Description
Elastic App Search ignored the `score` relevance sort token — its `GetSorting` kept a sort clause only when the field was in the schema or was exactly _score`, so the cross-provider `score` token (what the storefront and every other provider emit) was silently dropped. With relevance dropped but other clauses surviving, an empty-sort keyword search could come back ordered by tie-breakers (e.g. `priority`, `id`) instead of relevance.

This binds the relevance sort to App Search's built-in `_score` field for **both** the `score` and `_score` tokens (case-insensitive), mirroring the ElasticSearch8 `IsScoreField` behavior. No other providers or the storefront are affected — they already use `score`.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5370
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticAppSearch_3.1002.0-pr-51-ba41.zip